### PR TITLE
Fix issues with adapter trimming

### DIFF
--- a/modules/align_bowtie2.bds
+++ b/modules/align_bowtie2.bds
@@ -139,7 +139,7 @@ string[] bowtie2_PE( string fastq1, string fastq2, string o_dir, string log_o_di
 		//sys bowtie2 $param -X2000 --mm --threads $nth_bwt2 -x $bwt2_idx \
 		//	-1 $fastq1 -2 $fastq2 2>$log | \
 		//	samtools view -Su /dev/stdin | sambamba sort -t 1 /dev/stdin -o $bam
-		sys bowtie2 $param -X2000 --mm --threads $nth_bwt2 -x $bwt2_idx \
+		sys bowtie2 $param -X2000 --mm --local --threads $nth_bwt2 -x $bwt2_idx \
 			-1 $fastq1 -2 $fastq2 2>$log | \
 			samtools view -Su /dev/stdin | samtools sort - $prefix
 		sys samtools index $bam

--- a/modules/align_trim_adapter.bds
+++ b/modules/align_trim_adapter.bds
@@ -6,7 +6,7 @@ include "module_template.bds"
 
 
 help == adapter trimmer settings
-adapter_err_rate	:= "0.20" 	help Maximum allowed adapter error rate (# errors divided by the length of the matching adapter region, default: 0.20).
+adapter_err_rate	:= "0.10" 	help Maximum allowed adapter error rate (# errors divided by the length of the matching adapter region, default: 0.10).
 min_trim_len		:= 5 		help Minimum trim length for cutadapt -m, throwing away processed reads shorter than this (default: 5).
 
 wt_trim			:= "23h"	help Walltime for adapter trimming (default: 23h, 23:00:00).


### PR DESCRIPTION
- Allow local alignment to fix issue with 1 and 2bp adapters that are left untrimmed
- Allow lower adapter trimming error rate to avoid false positives